### PR TITLE
Fix #1: Add support for Windows

### DIFF
--- a/lib/parsers.js
+++ b/lib/parsers.js
@@ -49,9 +49,67 @@ function parserLinux(lines, search) {
   return ports;
 }
 
-// TODO: Windows parser (and add it below!)
+function parserWin32(lines, search) {
+  var ports = [];
+  if (!isNonEmptyArray(lines)) {
+    return [];
+  }
+
+  var tasklistLines = lines[0];
+  if (!isNonEmptyArray(tasklistLines)) {
+    return [];
+  }
+
+  var netstatLines = lines[1];
+  if (!isNonEmptyArray(netstatLines)) {
+    return [];
+  }
+
+  // Example tasklist syntax:
+  // b2g-bin.exe                  16180 RDP-Tcp#2                  1    129,560 K
+  var pidMap = {};
+  var tasklistRegex = new RegExp(
+    '^(' + search.join('|') + ')(?:-bin)?\\.exe\\s+([\\d]+)'
+  );
+
+  // Build a process name to pid map from tasklist
+  tasklistLines.forEach(function(line) {
+    var matches = tasklistRegex.exec(line);
+    if (matches) {
+      pidMap[matches[2]] = matches[1];
+    }
+  });
+
+  // Example netstat syntax:
+  //   TCP    127.0.0.1:2828         0.0.0.0:0              LISTENING       16180
+  //   TCP    127.0.0.1:61291        0.0.0.0:0              LISTENING       16180
+  var netstatRegex = new RegExp(
+    '^\\s+TCP\\s+\\d+\\.\\d+\\.\\d+\\.\\d+:(\\d+)\\s+' +
+    '\\d+\\.\\d+\\.\\d+\\.\\d+:\\d+\\s+LISTENING\\s+(\\d+)'
+  );
+
+  // Scrape out the listening ports from netstat that match pid map
+  netstatLines.forEach(function(line) {
+    var matches = netstatRegex.exec(line);
+    if (matches) {
+      var port = Number(matches[1]);
+      var pid = Number(matches[2]);
+      var type = pidMap[pid];
+      if (type && port && port !== MARIONETTE_PORT) {
+        ports.push({ type: pidMap[pid], port: port, pid: pid });
+      }
+    }
+  });
+
+  return ports;
+}
+
+function isNonEmptyArray(val) {
+  return Array.isArray(val) && val.length > 0;
+}
 
 module.exports = {
   darwin: parserDarwin,
-  linux: parserLinux
+  linux: parserLinux,
+  win32: parserWin32
 };

--- a/tests/unit/data/win32-firefox-netstat.txt
+++ b/tests/unit/data/win32-firefox-netstat.txt
@@ -1,0 +1,35 @@
+Active Connections
+
+  Proto  Local Address          Foreign Address        State           PID
+  TCP    0.0.0.0:135            0.0.0.0:0              LISTENING       812
+  TCP    0.0.0.0:445            0.0.0.0:0              LISTENING       4
+  TCP    0.0.0.0:902            0.0.0.0:0              LISTENING       2132
+  TCP    0.0.0.0:912            0.0.0.0:0              LISTENING       2132
+  TCP    0.0.0.0:2869           0.0.0.0:0              LISTENING       4
+  TCP    0.0.0.0:3389           0.0.0.0:0              LISTENING       1128
+  TCP    0.0.0.0:5357           0.0.0.0:0              LISTENING       4
+  TCP    0.0.0.0:17500          0.0.0.0:0              LISTENING       4448
+  TCP    0.0.0.0:27036          0.0.0.0:0              LISTENING       7072
+  TCP    0.0.0.0:43244          0.0.0.0:0              LISTENING       4240
+  TCP    0.0.0.0:49152          0.0.0.0:0              LISTENING       588
+  TCP    0.0.0.0:49153          0.0.0.0:0              LISTENING       968
+  TCP    0.0.0.0:49154          0.0.0.0:0              LISTENING       104
+  TCP    0.0.0.0:49155          0.0.0.0:0              LISTENING       1328
+  TCP    0.0.0.0:49157          0.0.0.0:0              LISTENING       684
+  TCP    0.0.0.0:49183          0.0.0.0:0              LISTENING       692
+  TCP    127.0.0.1:2828         0.0.0.0:0              LISTENING       12220
+  TCP    127.0.0.1:4370         0.0.0.0:0              LISTENING       4180
+  TCP    127.0.0.1:4380         0.0.0.0:0              LISTENING       4180
+  TCP    127.0.0.1:5037         0.0.0.0:0              LISTENING       2864
+  TCP    127.0.0.1:5037         127.0.0.1:60570        ESTABLISHED     2864
+  TCP    127.0.0.1:5354         0.0.0.0:0              LISTENING       1740
+  TCP    127.0.0.1:5354         127.0.0.1:49156        ESTABLISHED     1740
+  TCP    127.0.0.1:5354         127.0.0.1:49168        ESTABLISHED     1740
+  TCP    127.0.0.1:6000         0.0.0.0:0              LISTENING       12220
+  UDP    0.0.0.0:123            *:*                                    412
+  UDP    0.0.0.0:1900           *:*                                    4240
+  UDP    0.0.0.0:3389           *:*                                    1128
+  UDP    0.0.0.0:3702           *:*                                    1840
+  UDP    0.0.0.0:3702           *:*                                    412
+  UDP    0.0.0.0:3702           *:*                                    2552
+  UDP    0.0.0.0:3702           *:*                                    2552

--- a/tests/unit/data/win32-firefox-tasklist.txt
+++ b/tests/unit/data/win32-firefox-tasklist.txt
@@ -1,0 +1,28 @@
+Image Name                     PID Session Name        Session#    Mem Usage
+========================= ======== ================ =========== ============
+System Idle Process              0 Services                   0          4 K
+System                           4 Services                   0        316 K
+smss.exe                       396 Services                   0        528 K
+csrss.exe                      500 Services                   0      2,508 K
+wininit.exe                    588 Services                   0        940 K
+csrss.exe                      596 RDP-Tcp#2                  1      9,696 K
+winlogon.exe                   652 RDP-Tcp#2                  1      2,692 K
+services.exe                   684 Services                   0      5,516 K
+lsass.exe                      692 Services                   0     10,820 K
+svchost.exe                    768 Services                   0     13,456 K
+svchost.exe                    812 Services                   0      9,004 K
+atiesrxx.exe                   896 Services                   0      1,540 K
+dwm.exe                        924 RDP-Tcp#2                  1     80,632 K
+vmnat.exe                     1052 Services                   0      2,724 K
+vmnetdhcp.exe                 2076 Services                   0      7,432 K
+vmware-usbarbitrator64.ex     2100 Services                   0      1,652 K
+vmware-authd.exe              2132 Services                   0      3,296 K
+svchost.exe                   2552 Services                   0     11,008 K
+firefox.exe                  12220 RDP-Tcp#2                  1    129,560 K
+conhost.exe                  15536 RDP-Tcp#2                  1      3,208 K
+plugin-container.exe          4980 RDP-Tcp#2                  1     60,460 K
+taskeng.exe                  10844 RDP-Tcp#2                  1      5,476 K
+SearchProtocolHost.exe       10596 Services                   0     11,656 K
+SearchFilterHost.exe          2232 Services                   0      5,796 K
+tasklist.exe                  3636 RDP-Tcp#2                  1      5,376 K
+WmiPrvSE.exe                 14332 Services                   0      5,748 K

--- a/tests/unit/data/win32-no-runtimes-netstat.txt
+++ b/tests/unit/data/win32-no-runtimes-netstat.txt
@@ -1,0 +1,33 @@
+Active Connections
+
+  Proto  Local Address          Foreign Address        State           PID
+  TCP    0.0.0.0:135            0.0.0.0:0              LISTENING       812
+  TCP    0.0.0.0:445            0.0.0.0:0              LISTENING       4
+  TCP    0.0.0.0:902            0.0.0.0:0              LISTENING       2132
+  TCP    0.0.0.0:912            0.0.0.0:0              LISTENING       2132
+  TCP    0.0.0.0:2869           0.0.0.0:0              LISTENING       4
+  TCP    0.0.0.0:3389           0.0.0.0:0              LISTENING       1128
+  TCP    0.0.0.0:5357           0.0.0.0:0              LISTENING       4
+  TCP    0.0.0.0:17500          0.0.0.0:0              LISTENING       4448
+  TCP    0.0.0.0:27036          0.0.0.0:0              LISTENING       7072
+  TCP    0.0.0.0:43244          0.0.0.0:0              LISTENING       4240
+  TCP    0.0.0.0:49152          0.0.0.0:0              LISTENING       588
+  TCP    0.0.0.0:49153          0.0.0.0:0              LISTENING       968
+  TCP    0.0.0.0:49154          0.0.0.0:0              LISTENING       104
+  TCP    0.0.0.0:49155          0.0.0.0:0              LISTENING       1328
+  TCP    0.0.0.0:49157          0.0.0.0:0              LISTENING       684
+  TCP    0.0.0.0:49183          0.0.0.0:0              LISTENING       692
+  TCP    127.0.0.1:4370         0.0.0.0:0              LISTENING       4180
+  TCP    127.0.0.1:4380         0.0.0.0:0              LISTENING       4180
+  TCP    127.0.0.1:5037         0.0.0.0:0              LISTENING       2864
+  TCP    127.0.0.1:5037         127.0.0.1:60570        ESTABLISHED     2864
+  TCP    127.0.0.1:5354         0.0.0.0:0              LISTENING       1740
+  TCP    127.0.0.1:5354         127.0.0.1:49156        ESTABLISHED     1740
+  TCP    127.0.0.1:5354         127.0.0.1:49168        ESTABLISHED     1740
+  UDP    0.0.0.0:123            *:*                                    412
+  UDP    0.0.0.0:1900           *:*                                    4240
+  UDP    0.0.0.0:3389           *:*                                    1128
+  UDP    0.0.0.0:3702           *:*                                    1840
+  UDP    0.0.0.0:3702           *:*                                    412
+  UDP    0.0.0.0:3702           *:*                                    2552
+  UDP    0.0.0.0:3702           *:*                                    2552

--- a/tests/unit/data/win32-no-runtimes-tasklist.txt
+++ b/tests/unit/data/win32-no-runtimes-tasklist.txt
@@ -1,0 +1,27 @@
+Image Name                     PID Session Name        Session#    Mem Usage
+========================= ======== ================ =========== ============
+System Idle Process              0 Services                   0          4 K
+System                           4 Services                   0        316 K
+smss.exe                       396 Services                   0        528 K
+csrss.exe                      500 Services                   0      2,508 K
+wininit.exe                    588 Services                   0        940 K
+csrss.exe                      596 RDP-Tcp#2                  1      9,696 K
+winlogon.exe                   652 RDP-Tcp#2                  1      2,692 K
+services.exe                   684 Services                   0      5,516 K
+lsass.exe                      692 Services                   0     10,820 K
+svchost.exe                    768 Services                   0     13,456 K
+svchost.exe                    812 Services                   0      9,004 K
+atiesrxx.exe                   896 Services                   0      1,540 K
+dwm.exe                        924 RDP-Tcp#2                  1     80,632 K
+vmnat.exe                     1052 Services                   0      2,724 K
+vmnetdhcp.exe                 2076 Services                   0      7,432 K
+vmware-usbarbitrator64.ex     2100 Services                   0      1,652 K
+vmware-authd.exe              2132 Services                   0      3,296 K
+svchost.exe                   2552 Services                   0     11,008 K
+conhost.exe                  15536 RDP-Tcp#2                  1      3,208 K
+plugin-container.exe          4980 RDP-Tcp#2                  1     60,460 K
+taskeng.exe                  10844 RDP-Tcp#2                  1      5,476 K
+SearchProtocolHost.exe       10596 Services                   0     11,656 K
+SearchFilterHost.exe          2232 Services                   0      5,796 K
+tasklist.exe                  3636 RDP-Tcp#2                  1      5,376 K
+WmiPrvSE.exe                 14332 Services                   0      5,748 K

--- a/tests/unit/data/win32-simulator-netstat.txt
+++ b/tests/unit/data/win32-simulator-netstat.txt
@@ -1,0 +1,35 @@
+Active Connections
+
+  Proto  Local Address          Foreign Address        State           PID
+  TCP    0.0.0.0:135            0.0.0.0:0              LISTENING       812
+  TCP    0.0.0.0:445            0.0.0.0:0              LISTENING       4
+  TCP    0.0.0.0:902            0.0.0.0:0              LISTENING       2132
+  TCP    0.0.0.0:912            0.0.0.0:0              LISTENING       2132
+  TCP    0.0.0.0:2869           0.0.0.0:0              LISTENING       4
+  TCP    0.0.0.0:3389           0.0.0.0:0              LISTENING       1128
+  TCP    0.0.0.0:5357           0.0.0.0:0              LISTENING       4
+  TCP    0.0.0.0:17500          0.0.0.0:0              LISTENING       4448
+  TCP    0.0.0.0:27036          0.0.0.0:0              LISTENING       7072
+  TCP    0.0.0.0:43244          0.0.0.0:0              LISTENING       4240
+  TCP    0.0.0.0:49152          0.0.0.0:0              LISTENING       588
+  TCP    0.0.0.0:49153          0.0.0.0:0              LISTENING       968
+  TCP    0.0.0.0:49154          0.0.0.0:0              LISTENING       104
+  TCP    0.0.0.0:49155          0.0.0.0:0              LISTENING       1328
+  TCP    0.0.0.0:49157          0.0.0.0:0              LISTENING       684
+  TCP    0.0.0.0:49183          0.0.0.0:0              LISTENING       692
+  TCP    127.0.0.1:2828         0.0.0.0:0              LISTENING       16180
+  TCP    127.0.0.1:4370         0.0.0.0:0              LISTENING       4180
+  TCP    127.0.0.1:4380         0.0.0.0:0              LISTENING       4180
+  TCP    127.0.0.1:5037         0.0.0.0:0              LISTENING       2864
+  TCP    127.0.0.1:5037         127.0.0.1:60570        ESTABLISHED     2864
+  TCP    127.0.0.1:5354         0.0.0.0:0              LISTENING       1740
+  TCP    127.0.0.1:5354         127.0.0.1:49156        ESTABLISHED     1740
+  TCP    127.0.0.1:5354         127.0.0.1:49168        ESTABLISHED     1740
+  TCP    127.0.0.1:61291        0.0.0.0:0              LISTENING       16180
+  UDP    0.0.0.0:123            *:*                                    412
+  UDP    0.0.0.0:1900           *:*                                    4240
+  UDP    0.0.0.0:3389           *:*                                    1128
+  UDP    0.0.0.0:3702           *:*                                    1840
+  UDP    0.0.0.0:3702           *:*                                    412
+  UDP    0.0.0.0:3702           *:*                                    2552
+  UDP    0.0.0.0:3702           *:*                                    2552

--- a/tests/unit/data/win32-simulator-tasklist.txt
+++ b/tests/unit/data/win32-simulator-tasklist.txt
@@ -1,0 +1,28 @@
+Image Name                     PID Session Name        Session#    Mem Usage
+========================= ======== ================ =========== ============
+System Idle Process              0 Services                   0          4 K
+System                           4 Services                   0        316 K
+smss.exe                       396 Services                   0        528 K
+csrss.exe                      500 Services                   0      2,508 K
+wininit.exe                    588 Services                   0        940 K
+csrss.exe                      596 RDP-Tcp#2                  1      9,696 K
+winlogon.exe                   652 RDP-Tcp#2                  1      2,692 K
+services.exe                   684 Services                   0      5,516 K
+lsass.exe                      692 Services                   0     10,820 K
+svchost.exe                    768 Services                   0     13,456 K
+svchost.exe                    812 Services                   0      9,004 K
+atiesrxx.exe                   896 Services                   0      1,540 K
+dwm.exe                        924 RDP-Tcp#2                  1     80,632 K
+vmnat.exe                     1052 Services                   0      2,724 K
+vmnetdhcp.exe                 2076 Services                   0      7,432 K
+vmware-usbarbitrator64.ex     2100 Services                   0      1,652 K
+vmware-authd.exe              2132 Services                   0      3,296 K
+svchost.exe                   2552 Services                   0     11,008 K
+b2g-bin.exe                  16180 RDP-Tcp#2                  1    129,560 K
+conhost.exe                  15536 RDP-Tcp#2                  1      3,208 K
+plugin-container.exe          4980 RDP-Tcp#2                  1     60,460 K
+taskeng.exe                  10844 RDP-Tcp#2                  1      5,476 K
+SearchProtocolHost.exe       10596 Services                   0     11,656 K
+SearchFilterHost.exe          2232 Services                   0      5,796 K
+tasklist.exe                  3636 RDP-Tcp#2                  1      5,376 K
+WmiPrvSE.exe                 14332 Services                   0      5,748 K

--- a/tests/unit/test.parsers.js
+++ b/tests/unit/test.parsers.js
@@ -12,13 +12,28 @@ var oses = Object.keys(parsers);
 var searchAll = ['firefox', 'b2g'];
 var MARIONETTE_PORT = 2828;
 
-var darwinSimulatorOutput = fs.readFileSync(testsPath + '/data/darwin-simulator.txt', 'utf-8');
-var darwinFirefoxOutput = fs.readFileSync(testsPath + '/data/darwin-firefox.txt', 'utf-8');
-var darwinNoRuntimesOutput = fs.readFileSync(testsPath + '/data/darwin-no-runtimes.txt', 'utf-8');
-var linuxSimulatorOutput = fs.readFileSync(testsPath + '/data/linux-simulator.txt', 'utf-8');
-var linuxFirefoxOutput = fs.readFileSync(testsPath + '/data/linux-firefox.txt', 'utf-8');
-var linuxNoRuntimesOutput = fs.readFileSync(testsPath + '/data/linux-no-runtimes.txt', 'utf-8');
-// TODO: Windows test data
+function readTestFile(name) {
+  return fs.readFileSync(testsPath + '/data/' + name + '.txt', 'utf-8').split('\n');
+}
+
+var darwinSimulatorOutput = readTestFile('darwin-simulator');
+var darwinFirefoxOutput = readTestFile('darwin-firefox');
+var darwinNoRuntimesOutput = readTestFile('darwin-no-runtimes');
+var linuxSimulatorOutput = readTestFile('linux-simulator');
+var linuxFirefoxOutput = readTestFile('linux-firefox');
+var linuxNoRuntimesOutput = readTestFile('linux-no-runtimes');
+var win32SimulatorOutput = [
+  readTestFile('win32-simulator-tasklist'),
+  readTestFile('win32-simulator-netstat')
+];
+var win32FirefoxOutput = [
+  readTestFile('win32-firefox-tasklist'),
+  readTestFile('win32-firefox-netstat')
+];
+var win32NoRuntimesOutput = [
+  readTestFile('win32-no-runtimes-tasklist'),
+  readTestFile('win32-no-runtimes-netstat')
+];
 
 function getPortNumbers(results) {
   var portNumbers = [];
@@ -74,14 +89,14 @@ module.exports = {
 
     var sets = [
       { output: darwinSimulatorOutput, parser: parsers.darwin },
-      { output: linuxSimulatorOutput, parser: parsers.linux }
-      // TODO: Windows
+      { output: linuxSimulatorOutput, parser: parsers.linux },
+      { output: win32SimulatorOutput, parser: parsers.win32 }
     ];
 
     test.expect(sets.length);
 
     sets.forEach(function(resultSet) {
-      var lines = resultSet.output.split('\n');
+      var lines = resultSet.output;
       var result = resultSet.parser(lines, searchAll);
       var resultPorts = getPortNumbers(result);
       test.ok(resultPorts.indexOf(MARIONETTE_PORT) === -1);
@@ -99,14 +114,14 @@ module.exports = {
 
     var sets = [
       { output: darwinSimulatorOutput, parser: parsers.darwin, expectedPort: 54637 },
-      { output: linuxSimulatorOutput, parser: parsers.linux, expectedPort: 37566 }
-      // TODO: Windows
+      { output: linuxSimulatorOutput, parser: parsers.linux, expectedPort: 37566 },
+      { output: win32SimulatorOutput, parser: parsers.win32, expectedPort: 61291 }
     ];
 
     test.expect(sets.length);
 
     sets.forEach(function(resultSet) {
-      var lines = resultSet.output.split('\n');
+      var lines = resultSet.output;
       var result = resultSet.parser(lines, searchAll);
       var resultPorts = getPortNumbers(result);
       test.ok(resultPorts.indexOf(resultSet.expectedPort) !== -1);
@@ -122,14 +137,14 @@ module.exports = {
 
     var sets = [
       { output: darwinFirefoxOutput, parser: parsers.darwin, expectedPort: 6000 },
-      { output: linuxFirefoxOutput, parser: parsers.linux, expectedPort: 6000 }
-      // TODO: Windows
+      { output: linuxFirefoxOutput, parser: parsers.linux, expectedPort: 6000 },
+      { output: win32FirefoxOutput, parser: parsers.win32, expectedPort: 6000 }
     ];
 
     test.expect(sets.length);
 
     sets.forEach(function(resultSet) {
-      var lines = resultSet.output.split('\n');
+      var lines = resultSet.output;
       var result = resultSet.parser(lines, searchAll);
       var resultPorts = getPortNumbers(result);
       test.ok(resultPorts.indexOf(resultSet.expectedPort) !== -1);
@@ -145,14 +160,14 @@ module.exports = {
   noRuntimeAvailableNoPortReturned: function(test) {
     var sets = [
       { output: darwinNoRuntimesOutput, parser: parsers.darwin },
-      { output: linuxNoRuntimesOutput, parser: parsers.linux }
-      // TODO: Windows
+      { output: linuxNoRuntimesOutput, parser: parsers.linux },
+      { output: win32NoRuntimesOutput, parser: parsers.win32 }
     ];
 
     test.expect(sets.length);
 
     sets.forEach(function(resultSet) {
-      var lines = resultSet.output.split('\n');
+      var lines = resultSet.output;
       var result = resultSet.parser(lines, searchAll);
       var resultPorts = getPortNumbers(result);
       test.ok(resultPorts.length === 0);


### PR DESCRIPTION
* Change findPorts() to support multiple commands for win32

* Add win32 command output parser and test cases

* Small refactoring of tests