### PR TITLE
Fixes #4: Detect ports forwarded to connected devices

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 npm-debug.log
 .DS_Store
+*.sw?

--- a/README.md
+++ b/README.md
@@ -6,11 +6,12 @@
 
 This is part of the [node-firefox](https://github.com/mozilla/node-firefox) project.
 
-When runtimes have remote debugging enabled, they start a server that listens for incoming connections. This module can find those runtimes and in which port they are listening.
-
-## Current limitations
-
-We can only detect **Firefox Desktop** and **Firefox OS Simulators**. Devices connected via USB are exposed via adb, which makes differentiation difficult with the method we are using to detect runtimes.
+When runtimes have remote debugging enabled, they start a server that listens
+for incoming connections. Devices connected via USB can also have their remote
+debugging sockets forwarded to local TCP/IP ports by the Android Debug Bridge
+(adb). 
+  
+This module can find these runtimes and in which port they are listening.
 
 ## Installation
 
@@ -46,6 +47,8 @@ where `options` is a plain Object with any of the following:
 
 * `firefox`: look for Firefox Desktop instances
 * `firefoxOSSimulator`: look for Firefox OS Simulators
+* `firefoxOSDevice`: look for local ports forwarded to connected devices
+* `ignoreMultiplePortsPerDevice`: if there are multiple local ports forwarded to the same remote debugging port on a device, report only the first that is found (default: `true`)
 * `detailed`: query each found runtime for more information, such as the version, build time, processor, etc. The additional data will be added to the entry under a new `device` field.
 
 If no `options` are provided, or if `options` is an empty `Object` (`{}`), then `findPorts` will look for any runtimes, of any type.
@@ -66,11 +69,85 @@ findPorts({ firefoxOSSimulator: true }).then(function(results) {
 }, function(err) {
   console.log(err);
 });
+```
 
+The output from the above code might look like the following:
+```javascript
+[ { type: 'b2g', port: 56567, pid: 45876 },
+  { type: 'firefox', port: 6000, pid: 3718 },
+  { type: 'device', port: 8001, deviceId: '3739ced5' } ]
+```
+
+Use the `detailed` option for additional information:
+```javascript
 // Returns only Firefox OS simulators, with extra detailed output
-findPorts({ firefoxOSSimulator: true, detailed: true }).then(function(results) {
+findPorts({
+  firefoxOSSimulator: true, 
+  firefoxOSDevice: true,
+  detailed: true
+}).then(function(results) {
   console.log(results);
 });
+```
+
+Detailed output includes a lot more info:
+```javascript
+[ { type: 'b2g',
+    port: 56567,
+    pid: 45876,
+    device:
+     { appid: '{3c2e2abc-06d4-11e1-ac3b-374f68613e61}',
+       apptype: 'b2g',
+       vendor: 'Mozilla',
+       name: 'B2G',
+       version: '2.2.0.0-prerelease',
+       appbuildid: '20141123160201',
+       platformbuildid: '20141123160201',
+       platformversion: '36.0a1',
+       geckobuildid: '20141123160201',
+       geckoversion: '36.0a1',
+       changeset: '8c02f3280d0c',
+       useragent: 'Mozilla/5.0 (Mobile; rv:36.0) Gecko/20100101 Firefox/36.0',
+       locale: 'en-US',
+       os: 'B2G',
+       hardware: null,
+       processor: 'x86_64',
+       compiler: 'gcc3',
+       dpi: 258,
+       brandName: null,
+       channel: 'default',
+       profile: 'profile',
+       width: 1680,
+       height: 1050 },
+    release: '2.2.0.0-prerelease' },
+  { type: 'device',
+    port: 8001,
+    deviceId: '3739ced5',
+    device:
+     { appid: '{3c2e2abc-06d4-11e1-ac3b-374f68613e61}',
+       apptype: 'b2g',
+       vendor: 'Mozilla',
+       name: 'B2G',
+       version: '3.0.0.0-prerelease',
+       appbuildid: '20150320064705',
+       platformbuildid: '20150320064705',
+       platformversion: '39.0a1',
+       geckobuildid: '20150320064705',
+       geckoversion: '39.0a1',
+       changeset: 'b2e71f32548f',
+       locale: 'en-US',
+       os: 'B2G',
+       hardware: 'qcom',
+       processor: 'arm',
+       compiler: 'eabi',
+       brandName: null,
+       channel: 'nightly',
+       profile: 'default',
+       dpi: 254,
+       useragent: 'Mozilla/5.0 (Mobile; rv:39.0) Gecko/39.0 Firefox/39.0',
+       width: 320,
+       height: 569 },
+    release: '3.0.0.0-prerelease' } ]
 ```
 
 ## Running the tests

--- a/index.js
+++ b/index.js
@@ -7,58 +7,136 @@ var Promise = require('es6-promise').Promise;
 var exec = require('shelljs').exec;
 var FirefoxClient = require('firefox-client');
 var os = process.platform;
+
 var parsers = require('./lib/parsers');
+
 var commands = {
   darwin: 'lsof -i -n -P -sTCP:LISTEN',
   linux: 'netstat -lnptu',
   win32: ['tasklist', 'netstat -ano']
 };
 
+var adb = require('adbkit');
+var REMOTE_DEBUGGER_SOCKET = 'localfilesystem:/data/local/debugger-socket';
+
 module.exports = findPorts;
 
 function findPorts(opts) {
   opts = opts || {};
-  var results = [];
-  var search = [];
 
-  if (!opts.firefox && !opts.firefoxOSSimulator) {
-    search = ['firefox', 'b2g'];
-  }
-  if (opts.firefox) {
-    search.push('firefox');
-  }
-  if (opts.firefoxOSSimulator) {
-    search.push('b2g');
+  var isDefaultSearch = !opts.firefox &&
+                        !opts.firefoxOSSimulator &&
+                        !opts.firefoxOSDevice;
+  if (isDefaultSearch) {
+    // By default, search for all kinds of debugging ports.
+    opts.firefox = opts.firefoxOSSimulator = opts.firefoxOSDevice = true;
   }
 
-  if (opts.release && opts.release.length > 0) {
-    opts.detailed = true;
+  if (!opts.hasOwnProperty('ignoreMultiplePortsPerDevice')) {
+    // By default, ignore multiple debugging ports found for the same device.
+    opts.ignoreMultiplePortsPerDevice = true;
   }
 
-  var command = commands[os];
-  var parser = parsers[os];
+  return findLocalPorts(opts).then(function(results) {
+    return findForwardedPorts(opts, results);
+  }).then(function(results) {
+    return expandResults(opts, results);
+  });
+}
 
+
+function findLocalPorts(opts) {
   return new Promise(function(resolve, reject) {
+
+    var search = [];
+    if (opts.firefox) {
+      search.push('firefox');
+    }
+    if (opts.firefoxOSSimulator) {
+      search.push('b2g');
+    }
+    if (search.length === 0) {
+      return resolve([]);
+    }
+
+    var command = commands[os];
+    var parser = parsers[os];
 
     if (parser === undefined) {
       return reject(new Error(os + ' not supported yet'));
     }
 
     var lines = Array.isArray(command) ?
-      command.map(execAndSplitLines) : execAndSplitLines(command);
-    results = parser(lines, search);
+                command.map(execAndSplitLines) :
+                execAndSplitLines(command);
 
-    if (!opts.detailed) {
-      return resolve(results);
-    }
+    var results = parser(lines, search);
 
-    return Promise.all(results.map(getDeviceInfo))
-      .then(function(detailedResults) {
-        resolve(filterByRelease(detailedResults, opts.release));
-      });
+    return resolve(results);
+
+  });
+}
+
+
+function findForwardedPorts(opts, results) {
+
+  if (!opts.firefoxOSDevice) {
+    return results;
+  }
+
+  return adb.createClient().listForwards().then(function(ports) {
+
+    var seenDevices = {};
+
+    var deviceResults = ports.filter(function(port) {
+
+      // Filter out multiple ports per device when necessary.
+      if (opts.ignoreMultiplePortsPerDevice) {
+        var seenKey = port.serial;
+        if (opts.ignoreMultiplePortsPerDevice && seenKey in seenDevices) {
+          return false;
+        }
+        seenDevices[seenKey] = true;
+      }
+
+      // We only want local TCP/IP ports forwarded to remote debugging sockets.
+      return port.remote === REMOTE_DEBUGGER_SOCKET &&
+             port.local.indexOf('tcp:') === 0;
+
+    }).map(function(port) {
+
+      // Extract the port number from tcp:{port}
+      var portNumber = parseInt(port.local.substr(4));
+
+      return {
+        type: 'device',
+        port: portNumber,
+        deviceId: port.serial
+      };
+
+    });
+
+    return results.concat(deviceResults);
 
   });
 
+}
+
+
+function expandResults(opts, results) {
+
+  if (opts.release && opts.release.length > 0) {
+    opts.detailed = true;
+  }
+
+  if (!opts.detailed) {
+    return results;
+  }
+
+  return Promise.all(results.map(getDeviceInfo))
+    .then(function(detailedResults) {
+      return filterByRelease(detailedResults, opts.release);
+    });
 }
 
 

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Find ports where debuggable runtimes are listening",
   "main": "index.js",
   "dependencies": {
+    "adbkit": "^2.1.6",
     "es6-promise": "^2.0.1",
     "firefox-client": "^0.3.0",
     "shelljs": "^0.3.0"
@@ -16,7 +17,9 @@
     "gulp-nodeunit": "0.0.5",
     "gulp-replace": "^0.5.0",
     "jshint-stylish": "^1.0.0",
-    "node-firefox-build-tools": "^0.1.0"
+    "mockery": "^1.4.0",
+    "node-firefox-build-tools": "^0.1.0",
+    "nodemock": "^0.3.4"
   },
   "scripts": {
     "gulp": "gulp",

--- a/tests/unit/test.index.js
+++ b/tests/unit/test.index.js
@@ -1,0 +1,144 @@
+'use strict';
+
+/* global -Promise */
+
+var Promise = require('es6-promise').Promise;
+var mockery = require('mockery');
+var nodemock = require('nodemock');
+
+var REMOTE_DEBUGGER_SOCKET = 'localfilesystem:/data/local/debugger-socket';
+
+module.exports = {
+
+  'firefoxOSDevice option should find ports forwarded to remote debugging socket on devices': function(test) {
+
+    var port = 9999;
+    var deviceId = '8675309';
+    var localAddress = 'tcp:' + port;
+    var remoteAddress = 'localfilesystem:/data/local/debugger-socket';
+
+    // Report existing port forwards for the device.
+    var mocked = nodemock
+      .mock('listForwards')
+      .returns(new Promise(function(resolve, reject) {
+        resolve([
+          {
+            serial: deviceId,
+            local: localAddress,
+            remote: remoteAddress
+          }
+        ]);
+      }));
+
+    mocked.mock('createClient').returns({
+      listForwards: mocked.listForwards
+    });
+
+    mockery.registerMock('adbkit', {
+      createClient: mocked.createClient
+    });
+
+    // Enable mocks on a clear import cache
+    mockery.enable({
+      warnOnReplace: false,
+      warnOnUnregistered: false,
+      useCleanCache: true
+    });
+
+    // Require a freshly imported module for this test
+    var findPortsWithMocks = require('../../index');
+
+    findPortsWithMocks({ firefoxOSDevice: true }).catch(function(err) {
+      test.ifError(err);
+      test.done();
+    }).then(function(results) {
+
+      // Ensure all the mocks were called, and with the expected parameters
+      test.ok(mocked.assert());
+
+      test.deepEqual(results, [
+        { type: 'device', port: port, deviceId: deviceId }
+      ]);
+
+      mockery.disable();
+
+      test.done();
+
+    });
+  },
+
+  'ignoreMultiplePortsPerDevice option should filter local ports forwarded to the same remote port': function(test) {
+
+    var ports = [
+      { serial: '8675309',   local: 'tcp:8001', remote: REMOTE_DEBUGGER_SOCKET },
+      { serial: '8675309',   local: 'tcp:8002', remote: REMOTE_DEBUGGER_SOCKET },
+      { serial: 'omgwtfbbq', local: 'tcp:8003', remote: REMOTE_DEBUGGER_SOCKET },
+      { serial: 'omgwtfbbq', local: 'tcp:8004', remote: REMOTE_DEBUGGER_SOCKET }
+    ];
+
+    // Simplified minimal mockup of adbKit.createClient().listForwards()
+    mockery.registerMock('adbkit', {
+      createClient: function() {
+        return {
+          listForwards: function() {
+            return new Promise(function(resolve, reject) {
+              resolve(ports);
+            });
+          }
+        };
+      }
+    });
+
+    // Enable mocks on a clear import cache
+    mockery.enable({
+      warnOnReplace: false,
+      warnOnUnregistered: false,
+      useCleanCache: true
+    });
+
+    // Require a freshly imported module for this test
+    var findPortsWithMocks = require('../../index');
+
+    Promise.all([
+
+      // Default option, should filter multiple ports
+      findPortsWithMocks({ firefoxOSDevice: true }),
+
+      // true, same as default
+      findPortsWithMocks({ firefoxOSDevice: true,
+                           ignoreMultiplePortsPerDevice: true }),
+
+      // false, should yield multiple ports per device
+      findPortsWithMocks({ firefoxOSDevice: true,
+                           ignoreMultiplePortsPerDevice: false })
+
+    ]).then(function(resultSet) {
+
+      test.deepEqual(resultSet, [
+        [
+          { type: 'device', port: 8001, deviceId: '8675309' },
+          { type: 'device', port: 8003, deviceId: 'omgwtfbbq' }
+        ],
+        [
+          { type: 'device', port: 8001, deviceId: '8675309' },
+          { type: 'device', port: 8003, deviceId: 'omgwtfbbq' }
+        ],
+        [
+          { type: 'device', port: 8001, deviceId: '8675309' },
+          { type: 'device', port: 8002, deviceId: '8675309' },
+          { type: 'device', port: 8003, deviceId: 'omgwtfbbq' },
+          { type: 'device', port: 8004, deviceId: 'omgwtfbbq' }
+        ]
+      ]);
+
+      mockery.disable();
+
+      test.done();
+
+    }).catch(function(err) {
+      test.ifError(err);
+      test.done();
+    });
+  }
+
+};


### PR DESCRIPTION
Here's a first attempt at detecting ports forwarded to connected devices using adbkit.

I realized there were only tests for the parsers, and none for the main `index.js`. But, for this PR, I only added tests for the new functionality.

I think I might follow this up with another PR to enhance the tests to exercise the rest of the port finding dance. I could also work on those tests as a part of this PR, but I wanted to at least get this new functionality in front of some eyes first.